### PR TITLE
fix factory scaffold, missing bracket

### DIFF
--- a/lib/templates/v_0.4.0/client/scaffold-factory.js
+++ b/lib/templates/v_0.4.0/client/scaffold-factory.js
@@ -147,7 +147,7 @@ angular.module('Yote')
           console.log("update action failed 2 :(");
           console.log(data);
           deferred.reject(data);
-        
+        }
       }).error(function(err) {
         console.log("update action failed 1 :(");
         console.log(err);


### PR DESCRIPTION
causes any generated factory to break. looks like I accidentally deleted it in my last PR. https://github.com/fugitivelabs/yote-cli/pull/18/files#diff-ce781c7eebca59dee4d7a85263344c20L150
