### PR TITLE
error catching for yote version number

### DIFF
--- a/lib/apiResource.js
+++ b/lib/apiResource.js
@@ -1,10 +1,11 @@
 "use strict";
 
-var        fs   = require('fs'),
-        shell   = require('shelljs'),
-        chalk   = require('chalk');
+var fs = require('fs')
+    , shell = require('shelljs')
+    , chalk = require('chalk')
+    ;
 
-var  resource   = {};
+var resource = {};
 
 function getYoteVersion() {
   var pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));

--- a/lib/ngResource.js
+++ b/lib/ngResource.js
@@ -1,10 +1,11 @@
 "use strict";
 
-var        fs   = require('fs'),
-        shell   = require('shelljs'),
-        chalk   = require('chalk');
+var fs = require('fs')
+    , shell = require('shelljs')
+    , chalk = require('chalk')
+    ;
 
-var  resource   = {};
+var resource = {};
 
 function getYoteVersion() {
   var pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));

--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -1,15 +1,22 @@
 "use strict";
 
-var        fs   = require('fs'),
-        shell   = require('shelljs'),
-        chalk   = require('chalk');
+var fs = require('fs')
+    , shell = require('shelljs')
+    , chalk = require('chalk')
+    ;
 
-var  resource   = {};
+var resource = {};
 
 function getYoteVersion() {
-  var pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
-  console.log(pkg.version);
-  return pkg.version;
+  console.log("trying to get Yote version");
+  try {
+    var pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+    console.log(pkg.version);
+    return pkg.version;
+  } catch(e) {
+    //file didn't exist, return version 0 - catch for the error
+    return "0.4.0"; //default to latest version, should probably store this as a variable somewhere
+  }
 }
 
 function checkIfExists(path) {


### PR DESCRIPTION
Ran into this problem when using the cli to "yote gen" resources for the keynote project where packages.json is in a higher level dir. If the readfile fails, the whole things breaks. So, added a check and if it fails, just return the latest yote version number.