### PR TITLE
v1 of backup utils for yote projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yote",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "cli to generate yote apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yote",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "cli to generate yote apps",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yote",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "cli to generate yote apps",
   "main": "index.js",
   "scripts": {

--- a/tools/remote.js
+++ b/tools/remote.js
@@ -10,9 +10,10 @@ module.exports = function(program) {
 
   program
 
-  .command("remote <command>")
+  .command("remote")
   .action(function(...args) {
     console.log("REMOTE");
+    // console.log(args);
     // console.log(args.length);
     if(args.length == 1) {
       process.exit(0);
@@ -58,17 +59,18 @@ module.exports = function(program) {
       var outputRename = args[1];
     }
     // process.exit(0);
-    console.log(instanceName);
+    console.log("NAME: " + instanceName);
     // console.log(args);
     exec("gcloud compute instances list", function(err, stdout, stderr) {
-      // console.log("GOT INSTANCE LIST");
+      console.log("GOT INSTANCE LIST");
       // console.log(stdout);
       //string methods to extract the zone for this instance (required for ssh and backup)
       var split = stdout.split(/[\n\r\s]+/);
+      // console.log(split);
       var instanceIndex = split.indexOf(instanceName);
       // console.log(split[instanceIndex]);
       var zone = split[instanceIndex + 1];
-      console.log("ZONE: " + zone);
+      // console.log("ZONE: " + zone);
       //have name and zone, enough to ssh into instance
       //create fresh backup
       var nextCommand = `gcloud compute ssh grant@${instanceName} --zone ${zone} --command "`;

--- a/tools/remote.js
+++ b/tools/remote.js
@@ -39,7 +39,7 @@ module.exports = function(program) {
 
   function list(args) {
     console.log("LIST");
-    console.log(args);
+    // console.log(args);
     shell.exec("gcloud compute instances list");
   }
 

--- a/tools/remote.js
+++ b/tools/remote.js
@@ -1,0 +1,94 @@
+var fs        = require('fs')
+  , chalk     = require('chalk')
+  , shell     = require('shelljs')
+  , promptly  = require('promptly')
+  , config    = require('../package.json')
+  , exec      = require('child_process').exec
+  ;
+
+module.exports = function(program) {
+
+  program
+
+  .command("remote").action(function(...args) { //https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_operator
+    console.log("REMOTE");
+    // console.log(args);
+    // console.log(args.length);
+    if(args.length == 1) {
+      process.exit(0);
+    }
+    var switchArg = args.shift(); //remove first item
+    // console.log(args);
+    switch(switchArg) {
+      case 'backup':
+        backup(args);
+        break;
+      case 'list':
+        list(args);
+        break;
+      default:
+        console.log("default");
+        process.exit(0);
+    }
+    // console.log(cmd);
+    // console.log(options);
+
+  })
+
+  function list() {
+    console.log("LIST");
+    shell.exec("gcloud compute instances list");
+  }
+
+  function backup(args) {
+    console.log("BACKUP");
+    // console.log(args);
+    var instanceName = args.shift();
+    if(typeof(args[0]) !== "string") {
+      console.log("MUST SPECIFY DATA REMOTE DATABASE NAME");
+      process.exit(0);
+    }
+    var dbName = args[0];
+    console.log("DATABASE NAME: " + dbName);
+    // console.log(instanceName);
+    // console.log(args);
+    exec("gcloud compute instances list", function(err, stdout, stderr) {
+      // console.log("GOT INSTANCE LIST");
+      // console.log(stdout);
+      var split = stdout.split(/[\n\r\s]+/);
+      var instanceIndex = split.indexOf(instanceName);
+      // console.log(split[instanceIndex]);
+      var zone = split[instanceIndex + 1];
+      //have name and zone, enough to ssh into instance
+      //create fresh backup
+      var nextCommand = `gcloud compute ssh grant@${instanceName} --zone ${zone} --command "`;
+      nextCommand += `sudo docker run -v ~/backup/:/backup/ --rm --link mongodb:mongodb library/mongo bash -c 'mongodump -d ${args[0]} -o /backup/ --host mongodb'"`;
+      // console.log(nextCommand);
+      console.log("Creating backup on remote instance");
+      shell.exec(nextCommand); //actually creates the backup!!!!
+      //now copy files locally
+      nextCommand = `gcloud compute copy-files grant@${instanceName}:/home/grant/backup/${dbName} ./ --zone ${zone}`;
+      shell.exec(nextCommand);
+      
+
+    })
+
+
+  }
+
+  function findInstance() {
+    console.log("fetching instance list");
+    shell.exec("gcloud compute instances list");
+    console.log("fetched instances");
+  }
+
+  function makeRemoteBackup() {
+    console.log("make remote backup");
+  }
+
+  function fetchRemoveBackup() {
+    console.log("fetch remote backup");
+  }
+
+
+}

--- a/tools/remote.js
+++ b/tools/remote.js
@@ -8,6 +8,15 @@ var fs        = require('fs')
 
 module.exports = function(program) {
 
+  //notes:
+  // must have gcloud installed
+  // does not change your gcloud current project. have to change the manually
+  // not sure how it will work with other peoples certs
+
+  //todos:
+  // restore backup
+  // create instance
+
   program
 
   .command("remote")

--- a/yote-cli.js
+++ b/yote-cli.js
@@ -21,6 +21,7 @@ program
   .option('-b,    --build     <buildNum>', 'Select which version of Yote to install')
   .option('-H,    --howl', '', howl)
 
+require('./tools/remote')(program);
 
 program
   .command('create <appName>')


### PR DESCRIPTION
FORMAT: yote remote backup [INSTANCE_NAME] [DATABASE_NAME] [optional - output filename]

example:

'yote remote backup grant-test soflete' //creates local database backup
'yote remote backup grant-test soflete soflete-01-11-17' //creates named local database backup

also "yote remote list", which lists current project instances

NOTE: this requires "gcloud" to be installed. it also requires an ssh password a few times, which may or may not be set on other peoples machines. this is definitely a work in progress, and as such will likely only be useful to me for the time being. lots still left todo.