### PR TITLE
v0.8-release - react-native upgrade and mobile changes

### DIFF
--- a/lib/v_0.8.0/addMobileResource.js
+++ b/lib/v_0.8.0/addMobileResource.js
@@ -46,7 +46,7 @@ module.exports = function(resourceName) {
       utils.write(mobilePath + '/components/Create' + PascalName + '.js'
         , utils.readTemplateAndReplace(__dirname, '/mobile/components/Create.js' , replacements));
       // layout
-      utils.write(mobilePath + '/components/' + PascalName + '.js'
+      utils.write(mobilePath + '/components/' + PascalName + 'Layout.js'
         , utils.readTemplateAndReplace(__dirname, '/mobile/components/Layout.js' , replacements));
       // list
       utils.write(mobilePath + '/components/' + PascalName + 'List.js'

--- a/lib/v_0.8.0/init.js
+++ b/lib/v_0.8.0/init.js
@@ -179,20 +179,14 @@ module.exports = function(appName, options) {
     console.log();
     console.log();
     shell.cd("mobile");
-    shell.exec("react-native init --version='0.47.2' " + PascalName);
-    shell.sed('-i', 'Yote', PascalName, `./Yote/index.ios.js`);
-    shell.sed('-i', 'Yote', PascalName, `./Yote/index.android.js`);
-    shell.cp('-f', [`./Yote/index.ios.js`, `./Yote/index.android.js`, `./Yote/package.json` ], `./${PascalName}/`);
+    shell.exec("react-native init --version='0.50.3' " + PascalName);
+    shell.sed('-i', 'Yote', PascalName, `./Yote/index.js`);
+    shell.cp('-f', [`./Yote/index.js`, `./Yote/package.json` ], `./${PascalName}/`);
     shell.cp('-Rf', `./Yote/js/*`, `./${PascalName}/js`);
-    shell.sed('-i', 'Yote', PascalName, `./${PascalName}/js/setup.js`);
-    shell.sed('-i', 'Yote', PascalName, `./${PascalName}/js/setup.js`);
-    shell.sed('-i', 'Yote', PascalName, `./${PascalName}/js/setup.js`);
-    shell.sed('-i', `Yote`, PascalName, `./${PascalName}/js/YoteApp.js`);
-    shell.sed('-i', `Yote`, PascalName, `./${PascalName}/js/YoteApp.js`);
-    shell.sed('-i', `Yote`, PascalName, `./${PascalName}/js/app.json`);
     shell.sed('-i', 'Yote', PascalName, '../yote-project.json');
     shell.mv(`./${PascalName}/js/YoteApp.js`, `./${PascalName}/js/${PascalName}App.js`);
     shell.rm('-rf', './Yote');
+    shell.rm(`./${PascalName}/App.js`)
     shell.cd(appName);
     shell.exec('npm install');
     // shell.exec('react-native link');

--- a/lib/v_0.8.0/templates/mobile/components/Create.js
+++ b/lib/v_0.8.0/templates/mobile/components/Create.js
@@ -3,7 +3,8 @@
 */
 
 // import react things
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types'; 
 import ReactNative from 'react-native';
 import { connect } from 'react-redux';
 

--- a/lib/v_0.8.0/templates/mobile/components/Layout.js
+++ b/lib/v_0.8.0/templates/mobile/components/Layout.js
@@ -4,7 +4,8 @@
 */
 
 // import react/redux dependencies
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 // import react-native components & apis
@@ -34,7 +35,7 @@ import * as __name__Actions from '../__name__Actions'
 // import styles
 import __name__Styles from '../__name__Styles';
 
-class __PascalName__ extends Base {
+class __PascalName__Layout extends Base {
   constructor(props) {
     super(props);
     this._bind(
@@ -109,7 +110,7 @@ class __PascalName__ extends Base {
   }
 }
 
-__PascalName__.propTypes = {
+__PascalName__Layout.propTypes = {
   dispatch: PropTypes.func
 }
 
@@ -124,4 +125,4 @@ const mapStoreToProps = (store) => {
 
 export default connect(
   mapStoreToProps
-)(__PascalName__);
+)(__PascalName__Layout);

--- a/lib/v_0.8.0/templates/mobile/components/List.js
+++ b/lib/v_0.8.0/templates/mobile/components/List.js
@@ -4,7 +4,8 @@
 */
 
 // import react things
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 // import react-native components

--- a/lib/v_0.8.0/templates/mobile/components/ListItem.js
+++ b/lib/v_0.8.0/templates/mobile/components/ListItem.js
@@ -1,5 +1,6 @@
 // import react things
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 // import react-native components

--- a/lib/v_0.8.0/templates/mobile/components/Single.js
+++ b/lib/v_0.8.0/templates/mobile/components/Single.js
@@ -3,7 +3,8 @@
 */
 
 // import react things
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 // import react-native components

--- a/lib/v_0.8.0/templates/mobile/components/Update.js
+++ b/lib/v_0.8.0/templates/mobile/components/Update.js
@@ -3,7 +3,8 @@
 */
 
 // import react things
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import ReactNative from 'react-native';
 import { connect } from 'react-redux';
 

--- a/lib/v_0.8.0/templates/mobile/navigator.js
+++ b/lib/v_0.8.0/templates/mobile/navigator.js
@@ -16,15 +16,15 @@ import { StackNavigator } from 'react-navigation';
 
 // import __name__ components
 import Create__PascalName__ from './components/Create__PascalName__'; 
-import __PascalName__ from './components/__PascalName__'; 
+import __PascalName__Layout from './components/__PascalName__Layout'; 
 import Single__PascalName__ from './components/Single__PascalName__'; 
 import Update__PascalName__ from './components/Update__PascalName__'; 
 
 // horizontal screen transitions
 const CardNavigator = StackNavigator(
   {
-    __PascalName__: {
-      screen: __PascalName__
+    __PascalName__Layout: {
+      screen: __PascalName__Layout
     }
     , Single__PascalName__: {
       screen: Single__PascalName__
@@ -32,7 +32,7 @@ const CardNavigator = StackNavigator(
   }
   , {
       headerMode: 'none'
-      , initialRouteName: '__PascalName__'
+      , initialRouteName: '__PascalName__Layout'
     }
 );
 


### PR DESCRIPTION
- upgrade RN to 0.50.3
- import PropTypes from package in components
- cleaned up init to modify correct mobile files (files were changed slightly with new version of RN)
- changed resource files to be named ProductLayout.js instead of Product.js to match web