### PR TITLE
add __startName__ syntax to mobile resources

### DIFF
--- a/lib/v_0.8.0/addMobileResource.js
+++ b/lib/v_0.8.0/addMobileResource.js
@@ -10,10 +10,11 @@ module.exports = function(resourceName) {
   const name = utils.getNormalizedName(resourceName);
   const camelName = utils.camelCase(name);
   const PascalName = utils.capitalizeFirstLetter(camelName);
-  const allCaps = name.toUpperCase();
-  const lowercase = name.toLowerCase();
+  const allCaps = utils.startCase(name).toUpperCase();
+  const lowercase = utils.startCase(name).toLowerCase();
   const kebabName = utils.kebabCase(name);
   const actionCase = utils.actionCase(name);
+  const startName = utils.startCase(name);
   const mobileProjectName = utils.getYoteMobileProjectName();
 
   var mobilePath = "./mobile/"+mobileProjectName+"/js/modules/" + camelName;
@@ -26,7 +27,7 @@ module.exports = function(resourceName) {
   console.log(chalk.cyan("     Creating Mobile Resource called " + name));
 
   let replacements = {
-    name, camelName, PascalName, allCaps, lowercase, kebabName, actionCase
+    name, camelName, PascalName, allCaps, lowercase, kebabName, actionCase, startName
   }
   console.log(chalk.dim("     DIR", __dirname));
 

--- a/lib/v_0.8.0/templates/client/actions.js
+++ b/lib/v_0.8.0/templates/client/actions.js
@@ -1,5 +1,5 @@
 /**
- * All __name__ CRUD actions
+ * All __PascalName__ CRUD actions
  *
  * Actions are payloads of information that send data from the application
  * (i.e. Yote server) to the store. They are the _only_ source of information
@@ -39,7 +39,7 @@ const shouldFetchSingle = (state, id) => {
   } else if(new Date().getTime() - selected.lastUpdated > (1000 * 60 * 5)) {
     // it's been longer than 5 minutes since the last fetch, get a new one
     // console.log("Y shouldFetch - true: older than 5 minutes");
-    // also, don't automatically invalidate on server error. if server throws an error, 
+    // also, don't automatically invalidate on server error. if server throws an error,
     // that won't change on subsequent requests and we will have an infinite loop
     return true;
   } else {

--- a/lib/v_0.8.0/templates/client/globalStyles.scss
+++ b/lib/v_0.8.0/templates/client/globalStyles.scss
@@ -1,5 +1,5 @@
 /**
  * Uses SASS compiled to global stylesheet, yote.css
- * Any styles specific to the __PascalName__ module that you ALSO want globally
+ * Any styles specific to the __startName__ module that you ALSO want globally
  * available should live here.
  */

--- a/lib/v_0.8.0/templates/client/moduleStyles.css
+++ b/lib/v_0.8.0/templates/client/moduleStyles.css
@@ -1,6 +1,6 @@
 /**
  * To be used with CSS Modules rendered by the webpack.config.
- * Any styles specific to the __PascalName__ module should live here.
+ * Any styles specific to the __startName__ module should live here.
  * Import as neede like so:
  * ...
  * import __camelName__Styles from '__camelName__ModuleStyles.css';
@@ -12,5 +12,5 @@
  */
 
 .__kebabName__-item {
-  
+
 }

--- a/lib/v_0.8.0/templates/client/views/Create.js.jsx
+++ b/lib/v_0.8.0/templates/client/views/Create.js.jsx
@@ -75,7 +75,7 @@ class Create__PascalName__ extends Base {
               <__PascalName__Form
                 __name__={__name__}
                 cancelLink="/__kebabName__s"
-                formTitle="Create __PascalName__"
+                formTitle="Create __startName__"
                 formType="create"
                 handleFormChange={this._handleFormChange}
                 handleFormSubmit={this._handleFormSubmit}

--- a/lib/v_0.8.0/templates/client/views/List.js.jsx
+++ b/lib/v_0.8.0/templates/client/views/List.js.jsx
@@ -68,7 +68,7 @@ class __PascalName__List extends Base {
         <div className="flex">
           <section className="section">
             <div className="yt-container">
-              <h1> __PascalName__ List
+              <h1> __startName__ List
                 <Link className="yt-btn small u-pullRight" to={'/__kebabName__s/new'}> NEW __startName__ </Link>
               </h1>
               <hr/>

--- a/lib/v_0.8.0/templates/client/views/Single.js.jsx
+++ b/lib/v_0.8.0/templates/client/views/Single.js.jsx
@@ -53,7 +53,7 @@ class Single__PascalName__ extends Base {
         <div className="flex">
           <section className="section">
             <div className="yt-container">
-              <h3> Single __PascalName__ </h3>
+              <h3> Single __startName__ </h3>
               {isEmpty ?
                 (__camelName__Store.isFetching ? <h2>Loading...</h2> : <h2>Empty.</h2>)
                 :

--- a/lib/v_0.8.0/templates/client/views/Update.js.jsx
+++ b/lib/v_0.8.0/templates/client/views/Update.js.jsx
@@ -89,7 +89,7 @@ class Update__PascalName__ extends Base {
               <__PascalName__Form
                 __camelName__={__camelName__}
                 cancelLink={`/__kebabName__s/${__camelName__._id}`}
-                formTitle="Update __PascalName__"
+                formTitle="Update __startName__"
                 formType="update"
                 handleFormChange={this._handleFormChange}
                 handleFormSubmit={this._handleFormSubmit}

--- a/lib/v_0.8.0/templates/mobile/views/Create.js
+++ b/lib/v_0.8.0/templates/mobile/views/Create.js
@@ -20,7 +20,7 @@ import {
   , TextInput
   , TouchableOpacity
   , View
-} from 'react-native'; 
+} from 'react-native';
 
 // import global components
 import Base from '../../../global/components/BaseComponent';
@@ -134,7 +134,7 @@ class Create__PascalName__ extends Base {
       >
         <YTHeader
           rightItem={rightItem}
-          title="New __PascalName__"
+          title="New __startName__"
         />
         <ScrollView ref="myScrollView" keyboardDismissMode="interactive" keyboardShouldPersistTaps="handled" style={[__name__Styles.formWrapper]}>
           <View>
@@ -156,7 +156,7 @@ class Create__PascalName__ extends Base {
           </View>
           <View style={{paddingHorizontal: 10, paddingVertical: 20}}>
             <YTButton
-              caption={isFetching ? "Creating..." : "Create new __name__"}
+              caption={isFetching ? "Creating..." : "Create new __startName__"}
               isDisabled={!isFormValid}
               onPress={this._handleAction}
             />

--- a/lib/v_0.8.0/templates/mobile/views/Root.js
+++ b/lib/v_0.8.0/templates/mobile/views/Root.js
@@ -17,7 +17,7 @@ import {
   , TextInput
   , TouchableOpacity
   , View
-} from 'react-native'; 
+} from 'react-native';
 
 // import global components
 import ActionButton from '../../../global/components/ActionButton';
@@ -95,7 +95,7 @@ class __PascalName__Root extends Base {
     return (
       <View style={{flex: 1}}>
         <YTHeader
-          title="__PascalName__"
+          title="__startName__"
           rightItem={rightItem}
         >
         </YTHeader>

--- a/lib/v_0.8.0/templates/mobile/views/Single.js
+++ b/lib/v_0.8.0/templates/mobile/views/Single.js
@@ -19,7 +19,7 @@ import {
   , TextInput
   , TouchableOpacity
   , View
-} from 'react-native'; 
+} from 'react-native';
 
 // import global components
 import ActionButton from '../../../global/components/ActionButton';
@@ -84,7 +84,7 @@ class Single__PascalName__ extends Base {
       <View style={__name__Styles.container}>
         <YTHeader
           leftItem={leftItem}
-          title={'Single__PascalName__'}
+          title={'Single __startName__'}
           rightItem={rightItem}
         />
         <ScrollView>

--- a/lib/v_0.8.0/templates/mobile/views/Update.js
+++ b/lib/v_0.8.0/templates/mobile/views/Update.js
@@ -139,7 +139,7 @@ class Update__PascalName__ extends Base {
       >
         <YTHeader
           leftItem={leftItem}
-          title="Update __PascalName__"
+          title="Update __startName__"
         />
         <ScrollView ref="myScrollView" keyboardDismissMode="interactive" keyboardShouldPersistTaps="handled" style={[__name__Styles.formWrapper]}>
           <View>
@@ -163,7 +163,7 @@ class Update__PascalName__ extends Base {
           </View>
           <View style={{paddingHorizontal: 10, paddingVertical: 20}}>
             <YTButton
-              caption={isFetching ? "Updating..." : "Update __name__"}
+              caption={isFetching ? "Updating..." : "Update __startName__"}
               isDisabled={!isFormValid || isFetching}
               onPress={this._handleAction}
             />


### PR DESCRIPTION
When you add a resource via the CLI, this breaks up the camelCase names into it's two words for display.  So on the list page `yote add defaultBlock` becomes **Default Blocks** with a button that says **NEW DEFAULT BLOCK** instead of "DefaultBlocks"  