### PR TITLE
add in form helper pattern

### DIFF
--- a/lib/v_0.8.0/templates/client/components/Form.js.jsx
+++ b/lib/v_0.8.0/templates/client/components/Form.js.jsx
@@ -12,6 +12,7 @@ import { TextInput } from '../../../global/components/forms';
 
 function __PascalName__Form({
   cancelLink
+  , formHelpers
   , formTitle
   , formType
   , handleFormChange
@@ -34,7 +35,7 @@ function __PascalName__Form({
             <TextInput
               change={handleFormChange}
               label="Name"
-              name="name"
+              name="__camelName__.name"
               placeholder="Name (required)"
               required={true}
               value={__camelName__.name}
@@ -54,6 +55,7 @@ function __PascalName__Form({
 
 __PascalName__Form.propTypes = {
   cancelLink: PropTypes.string.isRequired
+  , formHelpers: PropTypes.object
   , formTitle: PropTypes.string
   , formType: PropTypes.string.isRequired
   , handleFormChange: PropTypes.func.isRequired
@@ -62,7 +64,8 @@ __PascalName__Form.propTypes = {
 }
 
 __PascalName__Form.defaultProps = {
-  formTitle: ''
+  formHelpers: {}
+  , formTitle: ''
 }
 
 export default __PascalName__Form;

--- a/lib/v_0.8.0/templates/client/views/Create.js.jsx
+++ b/lib/v_0.8.0/templates/client/views/Create.js.jsx
@@ -30,6 +30,11 @@ class Create__PascalName__ extends Base {
       __camelName__: _.cloneDeep(this.props.default__PascalName__)
       // NOTE: We don't want to actually change the store's defaultItem, just use a copy
       , formHelpers: {}
+      /**
+       * NOTE: formHelpers are useful for things like radio controls and other
+       * things that manipulate the form, but don't directly effect the state of
+       * the __camelName__
+       */ 
     }
     this._bind(
       '_handleFormChange'

--- a/lib/v_0.8.0/templates/client/views/Create.js.jsx
+++ b/lib/v_0.8.0/templates/client/views/Create.js.jsx
@@ -29,6 +29,7 @@ class Create__PascalName__ extends Base {
     this.state = {
       __camelName__: _.cloneDeep(this.props.default__PascalName__)
       // NOTE: We don't want to actually change the store's defaultItem, just use a copy
+      , formHelpers: {}
     }
     this._bind(
       '_handleFormChange'
@@ -40,10 +41,10 @@ class Create__PascalName__ extends Base {
     /**
      * This let's us change arbitrarily nested objects with one pass
      */
-    let new__PascalName__State = _.update( this.state.__camelName__, e.target.name, function() {
+    let newState = _.update( this.state, e.target.name, function() {
       return e.target.value;
     });
-    this.setState({__camelName__ :new__PascalName__State});
+    this.setState({newState});
   }
 
 
@@ -63,7 +64,7 @@ class Create__PascalName__ extends Base {
   }
 
   render() {
-    const { __camelName__ } = this.state;
+    const { __camelName__, formHelpers } = this.state;
     const isEmpty = (__camelName__.name === null || __camelName__.name === undefined);
     return (
       <__PascalName__Layout>
@@ -75,6 +76,7 @@ class Create__PascalName__ extends Base {
               <__PascalName__Form
                 __camelName__={__camelName__}
                 cancelLink="/__kebabNamePlural__"
+                formHelpers={formHelpers}
                 formTitle="Create __startName__"
                 formType="create"
                 handleFormChange={this._handleFormChange}

--- a/lib/v_0.8.0/templates/client/views/Create.js.jsx
+++ b/lib/v_0.8.0/templates/client/views/Create.js.jsx
@@ -34,7 +34,7 @@ class Create__PascalName__ extends Base {
        * NOTE: formHelpers are useful for things like radio controls and other
        * things that manipulate the form, but don't directly effect the state of
        * the __camelName__
-       */ 
+       */
     }
     this._bind(
       '_handleFormChange'
@@ -46,7 +46,7 @@ class Create__PascalName__ extends Base {
     /**
      * This let's us change arbitrarily nested objects with one pass
      */
-    let newState = _.update( this.state, e.target.name, function() {
+    let newState = _.update( this.state, e.target.name, () => {
       return e.target.value;
     });
     this.setState(newState);

--- a/lib/v_0.8.0/templates/client/views/Create.js.jsx
+++ b/lib/v_0.8.0/templates/client/views/Create.js.jsx
@@ -44,7 +44,7 @@ class Create__PascalName__ extends Base {
     let newState = _.update( this.state, e.target.name, function() {
       return e.target.value;
     });
-    this.setState({newState});
+    this.setState(newState);
   }
 
 

--- a/lib/v_0.8.0/templates/client/views/Update.js.jsx
+++ b/lib/v_0.8.0/templates/client/views/Update.js.jsx
@@ -32,8 +32,9 @@ class Update__PascalName__ extends Base {
     super(props);
     const { selected__PascalName__, __camelName__Map } = this.props;
     this.state = {
-      __camelName__: __camelName__Map[selected__PascalName__.id] ? { ...__camelName__Map[selected__PascalName__.id] } : {}
+      __camelName__: __camelName__Map[selected__PascalName__.id] ?  _.cloneDeep(__camelName__Map[selected__PascalName__.id]) : {}
       // NOTE: we don't want to change the store, just make changes to a copy
+      , formHelpers: {}
     }
     this._bind(
       '_handleFormChange'
@@ -49,16 +50,17 @@ class Update__PascalName__ extends Base {
   componentWillReceiveProps(nextProps) {
     const { selected__PascalName__, __camelName__Map } = nextProps;
     this.setState({
-      __camelName__: __camelName__Map[selected__PascalName__.id] ? { ...__camelName__Map[selected__PascalName__.id] } : {}
+      __camelName__: __camelName__Map[selected__PascalName__.id] ? _.cloneDeep(__camelName__Map[selected__PascalName__.id]) : {}
       //we don't want to actually change the store's __camelName__, just use a copy
+      , formHelpers: {}
     })
   }
 
   _handleFormChange(e) {
-    let new__PascalName__State = _.update( this.state.__camelName__, e.target.name, function() {
+    let newState = _.update( this.state, e.target.name, function() {
       return e.target.value;
     });
-    this.setState({__camelName__ :new__PascalName__State});
+    this.setState({newState});
   }
 
   _handleFormSubmit(e) {
@@ -77,7 +79,7 @@ class Update__PascalName__ extends Base {
 
   render() {
     const { selected__PascalName__, __camelName__Map } = this.props;
-    const { __camelName__ } = this.state;
+    const { __camelName__, formHelpers } = this.state;
     const isEmpty = (!__camelName__ || __camelName__._id === null || __camelName__._id === undefined);
     return  (
       <__PascalName__Layout>
@@ -89,6 +91,7 @@ class Update__PascalName__ extends Base {
               <__PascalName__Form
                 __camelName__={__camelName__}
                 cancelLink={`/__kebabNamePlural__/${__camelName__._id}`}
+                formHelpers={formHelpers}
                 formTitle="Update __startName__"
                 formType="update"
                 handleFormChange={this._handleFormChange}

--- a/lib/v_0.8.0/templates/client/views/Update.js.jsx
+++ b/lib/v_0.8.0/templates/client/views/Update.js.jsx
@@ -62,7 +62,7 @@ class Update__PascalName__ extends Base {
   }
 
   _handleFormChange(e) {
-    let newState = _.update( this.state, e.target.name, function() {
+    let newState = _.update( this.state, e.target.name, () => {
       return e.target.value;
     });
     this.setState(newState);

--- a/lib/v_0.8.0/templates/client/views/Update.js.jsx
+++ b/lib/v_0.8.0/templates/client/views/Update.js.jsx
@@ -35,6 +35,11 @@ class Update__PascalName__ extends Base {
       __camelName__: __camelName__Map[selected__PascalName__.id] ?  _.cloneDeep(__camelName__Map[selected__PascalName__.id]) : {}
       // NOTE: we don't want to change the store, just make changes to a copy
       , formHelpers: {}
+      /**
+       * NOTE: formHelpers are useful for things like radio controls and other
+       * things that manipulate the form, but don't directly effect the state of
+       * the __camelName__
+       */
     }
     this._bind(
       '_handleFormChange'

--- a/lib/v_0.8.0/templates/client/views/Update.js.jsx
+++ b/lib/v_0.8.0/templates/client/views/Update.js.jsx
@@ -60,7 +60,7 @@ class Update__PascalName__ extends Base {
     let newState = _.update( this.state, e.target.name, function() {
       return e.target.value;
     });
-    this.setState({newState});
+    this.setState(newState);
   }
 
   _handleFormSubmit(e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yote",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "yote-version": "0.8.0",
   "description": "cli to generate yote apps",
   "main": "index.js",


### PR DESCRIPTION
I've found this patter immensely useful in redStone and romr projects.  Particularly for things like radio controls and checking for changed DraftJS content. It keeps the state cleaner and makes it so the props passed to the form don't have to be updated every time you add some custom control to the state. The only state the form ever receives are the model and the formHelpers.   

I propose bringing this into the cli templates by default. 