### PR TITLE
3 - code split updates

### DIFF
--- a/lib/v_3.0.0/addWebResource.js
+++ b/lib/v_3.0.0/addWebResource.js
@@ -102,7 +102,9 @@ module.exports = function(resourceName, options) {
   // var sassRef = '\n@import "resources/' + camelName + "/" + camelName + 'GlobalStyles";';
   // utils.append("./web/config/yote.scss", sassRef);
 
-  var routesRef = "\nexport { default as " + camelNamePlural + " } from '../resources/" + camelName + "/" + PascalName + "Router.jsx';"
+  // var routesRef = "\nexport { default as " + camelNamePlural + " } from '../resources/" + camelName + "/" + PascalName + "Router.jsx';"
+  // lazy load the router by default
+  var routesRef = "\nexport const " + camelNamePlural + " = lazy(() => import('../resources/" + camelName + "/" + PascalName + "Router.jsx'));"
   utils.append("./web/src/config/resourceRoutes.js", routesRef);
 
   var reducersRef = "\nexport { default as " + camelName + " } from '../resources/" + camelName + "/" + camelName + "Store.js';"

--- a/lib/v_3.0.0/templates/server/api.js
+++ b/lib/v_3.0.0/templates/server/api.js
@@ -22,8 +22,8 @@ module.exports = (router) => {
   //   __camelName__.getListWithArgs
   // )
 
-  // router.post('/api/__kebabNamePlural__', __camelName__.createSingle);
-  router.post('/api/__kebabNamePlural__', requireLogin, __camelName__.createSingle);
+  router.post('/api/__kebabNamePlural__', __camelName__.createSingle);
+  // router.post('/api/__kebabNamePlural__', requireLogin, __camelName__.createSingle);
 
   router.put('/api/__kebabNamePlural__/:id', requireLogin, __camelName__.updateSingleById);
 

--- a/lib/v_3.0.0/templates/web/components/Form.jsx
+++ b/lib/v_3.0.0/templates/web/components/Form.jsx
@@ -33,9 +33,10 @@ const __PascalName__Form = ({
       <form name='__camelName__Form' className="" onSubmit={handleSubmit}>
         {header}
         <TextInput
+          autoFocus={true}
           name='name'
           label='Name'
-          value={__camelName__.name || ''}
+          value={__camelName__?.name || ''}
           change={handleChange}
           disabled={disabled}
           required={true}

--- a/lib/v_3.0.0/templates/web/components/Layout.jsx
+++ b/lib/v_3.0.0/templates/web/components/Layout.jsx
@@ -8,16 +8,28 @@
 
 // import primary libraries
 import React from 'react'
+import PropTypes from 'prop-types'
 
 // import global components
 import DefaultLayout from '../../../global/components/layouts/DefaultLayout.jsx'
 
-const __PascalName__Layout = ({ ...props }) => {
+const __PascalName__Layout = ({ children, className, title }) => {
   return (
-    <DefaultLayout title={props.title}>
-      {props.children}
+    <DefaultLayout title={title} className={className}>
+      {children}
     </DefaultLayout>
   )
 }
 
-export default __PascalName__Layout
+__PascalName__Layout.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node)
+    , PropTypes.node
+  ]).isRequired
+  , className: PropTypes.string
+  , title: PropTypes.string
+}
+
+__PascalName__Layout.Skeleton = DefaultLayout.Skeleton;
+
+export default __PascalName__Layout;

--- a/lib/v_3.0.0/templates/web/router.jsx
+++ b/lib/v_3.0.0/templates/web/router.jsx
@@ -45,7 +45,7 @@ const __PascalName__Router = () => {
         breadcrumbs={[{display: 'All __camelNamePlural__', path: '/__kebabNamePlural__'}, {display: '__PascalName__ Details', path: `/__kebabNamePlural__/${__camelName__Id}`}, {display: 'Update', path: null}]}
         component={Update__PascalName__}
         exact
-        // login={true}
+        login={true}
         path='/__kebabNamePlural__/:__camelName__Id/update'
         // admin='admin'
       />


### PR DESCRIPTION
Lazy import routers on new resources. Completes [this one](https://app.shortcut.com/pro-ficiency/story/3153/yote-implement-route-based-code-splitting-by-default).
Also some small clean up stuff.

Brings the cli up to date with the outstanding yote 3 PRs.